### PR TITLE
ReadTheDocs Configuration file fix

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,6 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-   version: "3.10"
    install:
       - method: pip
         path: .


### PR DESCRIPTION
**Details of Changes:**

1. **Configuration file fix:**
   - Fixed a non-working .readthedocs.yaml configuration file by removing a duplicate python version specification