### PR TITLE
Adversarial Debiasing hardcoded tensorflow version

### DIFF
--- a/orangecontrib/fairness/widgets/owadversarialdebiasing.py
+++ b/orangecontrib/fairness/widgets/owadversarialdebiasing.py
@@ -7,7 +7,8 @@ from Orange.data import Table
 from Orange.widgets.utils.concurrent import TaskState, ConcurrentWidgetMixin
 from Orange.base import Model
 from Orange.widgets.widget import Msg
-from orangecanvas.application.addons import AddonManagerDialog
+
+from orangecanvas.application.addons import AddonManagerDialog, Installable
 
 from AnyQt.QtWidgets import QFormLayout, QLabel, QVBoxLayout, QPushButton
 from AnyQt.QtCore import Qt
@@ -216,7 +217,7 @@ class OWAdversarialDebiasing(ConcurrentWidgetMixin, OWBaseLearner):
         label.setWordWrap(True)
         layout.addWidget(label)
         button = QPushButton("Install TensorFlow")
-        button.clicked.connect(self.instaall_tensorflow)
+        button.clicked.connect(self.install_tensorflow)
         layout.addWidget(button)
         
         box = gui.widgetBox(self.controlArea, True, orientation=layout)
@@ -224,12 +225,25 @@ class OWAdversarialDebiasing(ConcurrentWidgetMixin, OWBaseLearner):
         self.Error.add_message("no_tensorflow", TENSORFLOW_NOT_INSTALLED)
         self.Error.no_tensorflow()
     
-    def instaall_tensorflow(self):
+    def install_tensorflow(self):
         """
-        Installs tensorflow using the AddonManagerDialog
+        Installs tensorflow
         """
+
+        installable = Installable(
+            name='tensorflow',
+            version='2.15.0',
+            summary='TensorFlow is an open source machine learning framework for everyone.',
+            description="[![Python](https://img.shields.io/pypi/pyversions/tensorflow.svg?style=plastic)](https://badge.fury.io/py/tensorflow)\n[![PyPI](https://badge.fury.io/py/tensorflow.svg)](https://badge.fury.io/py/tensorflow)\n\nTensorFlow is an open source software library for high performance numerical\ncomputation. Its flexible architecture allows easy deployment of computation\nacross a variety of platforms (CPUs, GPUs, TPUs), and from desktops to clusters\nof servers to mobile and edge devices.\n\nOriginally developed by researchers and engineers from the Google Brain team\nwithin Google's AI organization, it comes with strong support for machine\nlearning and deep learning and the flexible numerical computation core is used\nacross many other scientific domains. TensorFlow is licensed under [Apache\n2.0](https://github.com/tensorflow/tensorflow/blob/master/LICENSE).\n",
+            package_url='https://pypi.org/project/tensorflow/',
+            release_urls=[],
+            requirements = ["absl-py (>=1.0.0)","astunparse (>=1.6.0)","flatbuffers (>=23.5.26)","gast (!=0.5.0,!=0.5.1,!=0.5.2,>=0.2.1)","google-pasta (>=0.1.1)","h5py (>=2.9.0)","libclang (>=13.0.0)","ml-dtypes (~=0.2.0)","numpy (<2.0.0,>=1.23.5)","opt-einsum (>=2.3.2)","packaging","protobuf (!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.20.3)","setuptools","six (>=1.12.0)","termcolor (>=1.1.0)","typing-extensions (>=3.6.6)","wrapt (<1.15,>=1.11.0)","tensorflow-io-gcs-filesystem (>=0.23.1)","grpcio (<2.0,>=1.24.3)","tensorboard (<2.16,>=2.15)","tensorflow-estimator (<2.16,>=2.15.0)","keras (<2.16,>=2.15.0)","nvidia-cublas-cu12 (==12.2.5.6) ; extra == 'and-cuda'","nvidia-cuda-cupti-cu12 (==12.2.142) ; extra == 'and-cuda'","nvidia-cuda-nvcc-cu12 (==12.2.140) ; extra == 'and-cuda'","nvidia-cuda-nvrtc-cu12 (==12.2.140) ; extra == 'and-cuda'","nvidia-cuda-runtime-cu12 (==12.2.140) ; extra == 'and-cuda'","nvidia-cudnn-cu12 (==8.9.4.25) ; extra == 'and-cuda'","nvidia-cufft-cu12 (==11.0.8.103) ; extra == 'and-cuda'","nvidia-curand-cu12 (==10.3.3.141) ; extra == 'and-cuda'","nvidia-cusolver-cu12 (==11.5.2.141) ; extra == 'and-cuda'","nvidia-cusparse-cu12 (==12.1.2.141) ; extra == 'and-cuda'","nvidia-nccl-cu12 (==2.16.5) ; extra == 'and-cuda'","nvidia-nvjitlink-cu12 (==12.2.140) ; extra == 'and-cuda'","tensorrt (==8.6.1.post1) ; extra == 'and-cuda'","tensorrt-bindings (==8.6.1) ; extra == 'and-cuda'","tensorrt-libs (==8.6.1) ; extra == 'and-cuda'"],
+            description_content_type='text/markdown',
+        )
+
         manager = AddonManagerDialog(self)
-        manager.runQueryAndAddResults(["tensorflow"])
+        manager.runQueryAndAddResults([])
+        manager.addInstallable(installable)
 
     def add_main_layout(self):
         if is_tensorflow_installed():
@@ -341,5 +355,4 @@ class OWAdversarialDebiasing(ConcurrentWidgetMixin, OWBaseLearner):
 
 if __name__ == "__main__":
     from Orange.widgets.utils.widgetpreview import WidgetPreview
-
     WidgetPreview(OWAdversarialDebiasing).run()


### PR DESCRIPTION
This pull request addresses an issue where users without TensorFlow pre-installed encountered problems when attempting to install the latest version through our interface. We have now pinned the TensorFlow installation to version 2.15.0, which should be stable and working with the addon.